### PR TITLE
Add support for mappings in the parameters file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The basic structure of the file in JSON:
   "parameters": {},
   "compile_parameters": {},
   "apply_stacks": [],
+  "mappings": {},
   "stacks": {}
 }
 ~~~
@@ -56,6 +57,7 @@ Break down of the keys:
 * `parameters` - Run time parameters sent to the orchestration API
 * `compile_parameters` - Compile time parameters used to generate the template
 * `apply_stacks` - List of stacks whose outputs should be applied
+* `mappings` - Hash of [STACK\_\_]old\_key new\_key to remap after apply\_stack
 * `stacks`- Nested stack information
 
 #### Infrastructure Mode

--- a/lib/sfn-parameters/infrastructure.rb
+++ b/lib/sfn-parameters/infrastructure.rb
@@ -18,6 +18,7 @@ module Sfn
         config[:parameters] ||= Smash.new
         config[:compile_parameters] ||= Smash.new
         config[:apply_stack] ||= []
+        config[:apply_mapping] ||= Smash.new
         stack_name = arguments.first
         content = load_file_for(stack_name)
         process_information_hash(content, [])
@@ -63,12 +64,15 @@ module Sfn
         hash.fetch(:stacks, {}).each do |key, value|
           process_information_hash(value, [*path, Bogo::Utility.camel(key)].compact)
         end
+        hash.fetch(:mappings, {}).each do |key, value|
+          value = [*path, Bogo::Utility.camel(value)].compact.map(&:to_s).join('__')
+          config[:apply_mapping][key] = value
+        end
         hash.fetch(:apply_stacks, []).each do |s_name|
           config[:apply_stack] << s_name
         end
         true
       end
-
     end
   end
 end


### PR DESCRIPTION
Hi Chris, hope you're well ... Hadn't poked around sparkleformation in a while, but I have to say you've built some pretty cool tools here !

This minor PR adds simple support for mappings within the parameters file to that we can populate the apply_mappings hash which is required by apply_stacks. 
