### PR TITLE
Recursively search for stack config under stacks directory

### DIFF
--- a/lib/sfn-parameters/stacks.rb
+++ b/lib/sfn-parameters/stacks.rb
@@ -10,7 +10,7 @@ module Sfn
       # @param stack_name [String]
       # @return [Smash]
       def load_file_for(stack_name)
-        root_path = config.fetch(:sfn_parameters, :directory, 'stacks')
+        root_path = config.fetch(:sfn_parameters, :directory, 'stacks', '**')
         paths = Dir.glob(File.join(root_path, "#{stack_name}{#{VALID_EXTENSIONS.join(',')}}")).map(&:to_s)
         if(paths.size > 1)
           raise ArgumentError.new "Multiple parameter file matches encountered! (#{paths.join(', ')})"


### PR DESCRIPTION
Convenience feature to allow stack files to exist anywhere under the stacks directory.

Much like template files can exists anywhere under the templates directory our users would like the same behavior in stacks. It allows them to organize stack files however they see fit.

There might be a downside or problem doing this but not sure what that'd be. :) 