### PR TITLE
Allow show command to be file format agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ library. This allows defining the file in a serialization format
 ### Encryption
 
 This callback also supports encrypting stack parameter information for storage. The callback
-adds a `parameters` command for handling encryption/decryption.
+adds a `parameters` command for handling encryption/decryption. Encryption is currently only
+supported when using JSON format parameter files.
 
 #### Configuration
 
@@ -233,6 +234,12 @@ $ sfn parameters lock my-test-stack
 
 ~~~
 $ sfn parameters unlock my-test-stack
+~~~
+
+##### Show existing values (as JSON)
+
+~~~
+$ sfn parameters show my-test-stack
 ~~~
 
 _NOTE: Full paths can also be used when defining parameters file._

--- a/lib/sfn-parameters/command.rb
+++ b/lib/sfn-parameters/command.rb
@@ -72,7 +72,7 @@ module Sfn
       # @param item [String] item to lock
       def run_action_show(item)
         item = validate_item(item)
-        content = load_json(File.read(item)).to_smash
+        content = Bogo::Config.new(item).data
         if(content[:sfn_parameters_lock])
           ui.print ui.color(' *', :bold)
           ui.print " Unlocking #{ui.color(item, :bold)} for display... "

--- a/lib/sfn-parameters/command.rb
+++ b/lib/sfn-parameters/command.rb
@@ -164,33 +164,24 @@ module Sfn
         if(item.to_s.empty?)
           raise NameError.new 'Item name is required. No item name provided.'
         end
-        items = [
-          item,
-          File.join(
-            config.fetch(
-              :sfn_parameters, :directory, 'stacks'
+        items = [item]
+        ['', '.json', '.rb', '.xml', '.yaml', '.yml'].each do |extension|
+          items += [
+            File.join(
+              config.fetch(
+                :sfn_parameters, :directory, 'stacks'
+              ),
+              "#{item}#{extension}"
             ),
-            item
-          ),
-          File.join(
-            config.fetch(
-              :sfn_parameters, :directory, 'stacks'
-            ),
-            "#{item}.json"
-          ),
-          File.join(
-            config.fetch(
-              :sfn_parameters, :directory, 'infrastructure'
-            ),
-            item
-          ),
-          File.join(
-            config.fetch(
-              :sfn_parameters, :directory, 'infrastructure'
-            ),
-            "#{item}.json"
-          )
-        ].map{|item| File.expand_path(item) }.uniq
+            File.join(
+              config.fetch(
+                :sfn_parameters, :directory, 'infrastructure'
+              ),
+              "#{item}#{extension}"
+            )
+          ]
+        end
+        items.map!{ |item| File.expand_path(item) }.uniq
         valid = items.find_all do |file|
           File.exist?(file)
         end


### PR DESCRIPTION
Currently the `sfn parameters show` command only works for stack files using JSON serialization.

This PR allows the `show` command to display stack config for any bogo-config serialization type (that said the output of `show` is always JSON format, but still useful I think).