### PR TITLE
Refactored add support for customized parameter resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,57 @@ $ sfn parameters show my-test-stack
 
 _NOTE: Full paths can also be used when defining parameters file._
 
+## Extending functionality (Resolvers)
+
+Parameters can be fetched from remote locations using Resolvers. Resolvers
+allow parameter values to be dynamically loaded via customized implementations.
+
+### Resolver usage
+
+Parameter values will be loaded via a resolver when the value of the
+parameter is a hash which includes a `resolver` key. The `resolver` key
+identifies the name of the resolver which should be loaded. For example:
+
+~~~json
+{
+  "parameters": {
+    "stack_creator": {
+      "resolver": "my_resolver",
+      "custom_key": "custom_value"
+    }
+  }
+}
+~~~
+
+This will create an instance of the `MyResolver` class and will then
+call the `MyResolver#resolve` with the value `{"custom_key" => "custom_value"}`.
+
+### Resolver implementation
+
+New resolvers can be created by subclassing the `SfnParameters::Resolver`
+class and implementing a `#resolve` method. An optional `#setup` method
+is available for setting up the instance. This is called during instance
+creation and has the entire sfn configuration available via the `#config`
+method.
+
+~~~ruby
+require "sfn-parameters"
+
+class MyResolver < SfnParameters::Resolver
+  def setup
+    # any custom setup
+  end
+
+  def resolve(value)
+    if value["custom_key"] == "custom_value"
+      "spox"
+    else
+      "unknown"
+    end
+  end
+end
+~~~
+
 # Info
 
 * Repository: https://github.com/sparkleformation/sfn-parameters

--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ class MyResolver < SfnParameters::Resolver
 end
 ~~~
 
+### Resolvers
+
+List of known resolvers for sfn-parameters:
+
+*
+
 # Info
 
 * Repository: https://github.com/sparkleformation/sfn-parameters

--- a/README.md
+++ b/README.md
@@ -269,6 +269,23 @@ identifies the name of the resolver which should be loaded. For example:
 This will create an instance of the `MyResolver` class and will then
 call the `MyResolver#resolve` with the value `{"custom_key" => "custom_value"}`.
 
+If the value to resolve is not a complex value, the configuration can
+be reduced to a single key/value pair where the key is the name of the
+resolver, and the value is the value to be resolved. This would look like:
+
+~~~json
+{
+  "parameters": {
+    "stack_creator": {
+      "my_resolver": "custom_value"
+    }
+  }
+}
+~~~
+
+This will create an instance of the `MyResolver` class and will then
+call the `MyResolver#resolve` with the value `"custom_value"`.
+
 ### Resolver implementation
 
 New resolvers can be created by subclassing the `SfnParameters::Resolver`

--- a/lib/sfn-parameters.rb
+++ b/lib/sfn-parameters.rb
@@ -1,6 +1,7 @@
 require "sfn"
 
 module SfnParameters
+  autoload :Resolver, "sfn-parameters/resolver"
   autoload :Safe, "sfn-parameters/safe"
   autoload :Utils, "sfn-parameters/utils"
 end

--- a/lib/sfn-parameters/infrastructure.rb
+++ b/lib/sfn-parameters/infrastructure.rb
@@ -4,6 +4,7 @@ module Sfn
   class Callback
     # Auto load stack parameters for infrastructure pattern
     class ParametersInfrastructure < Callback
+      include Bogo::Memoization
       include Sfn::Utils::JSON
       include SfnParameters::Utils
 
@@ -59,18 +60,18 @@ module Sfn
         end
         hash.fetch(:parameters, {}).each do |key, value|
           key = [*path, key].compact.map(&:to_s).join("__")
-          if current_value = config[:parameters][key]
+          if current_value = config.get(:parameters, key)
             ui.debug "Not setting template parameter `#{key}`. Already set within config. (`#{current_value}`)"
           else
-            config[:parameters][key] = value
+            config.set(:parameters, key, resolve(value))
           end
         end
         hash.fetch(:compile_parameters, {}).each do |key, value|
           key = [*path, key].compact.map(&:to_s).join("__")
-          if current_value = config[:compile_parameters][key]
+          if current_value = config.get(:compile_parameters, key)
             ui.debug "Not setting compile time parameter `#{key}`. Already set within config. (`#{current_value}`)"
           else
-            config[:compile_parameters][key] = value
+            config.set(:compile_parameters, key, resolve(value))
           end
         end
         hash.fetch(:stacks, {}).each do |key, value|
@@ -78,12 +79,39 @@ module Sfn
         end
         hash.fetch(:mappings, {}).each do |key, value|
           value = [*path, Bogo::Utility.camel(value)].compact.map(&:to_s).join("__")
-          config[:apply_mapping][key] = value
+          config.set(:apply_mapping, key, value)
         end
         hash.fetch(:apply_stacks, []).each do |s_name|
           config[:apply_stack] << s_name
         end
+        config[:apply_stack].uniq!
         true
+      end
+
+      # Load value via resolver if defined
+      #
+      # @param value [Object]
+      # @return [Object]
+      def resolve(value)
+        if value.is_a?(Hash) && value.to_smash.key?(:resolver)
+          value = value.to_smash
+          resolver_name = Bogo::Utility.camel(value.delete(:resolver))
+          resolver = load_resolver(resolver_name)
+          resolver.resolve(value)
+        else
+          value
+        end
+      end
+
+      # Load given resolver
+      #
+      # @param resolver_name [String]
+      # @return [Resolver]
+      def load_resolver(resolver_name)
+        memoize(resolver_name) do
+          klass = SfnParameters::Resolver.detect_resolver(resolver_name)
+          klass.new(config)
+        end
       end
     end
   end

--- a/lib/sfn-parameters/resolver.rb
+++ b/lib/sfn-parameters/resolver.rb
@@ -1,0 +1,68 @@
+require "sfn-parameters"
+
+module SfnParameters
+  # Parameter resolver
+  class Resolver
+    @@resolvers = {}
+
+    # :nodoc:
+    # Used only for testing
+    def self.reset!
+      @@resolvers.clear
+    end
+
+    # :nodoc:
+    def self.inherited(klass)
+      if klass.name.nil?
+        raise ArgumentError.new("Unnamed classes are not supported")
+      end
+      klass_key = Bogo::Utility.snake(klass.name).gsub("::", "_")
+      @@resolvers[klass_key] = klass
+    end
+
+    # @return [Array<Resolver>]
+    def self.resolvers
+      @@resolvers.values
+    end
+
+    # Find resolver that matches given name
+    #
+    # @param name [String] resolver identifier name
+    # @return [Resolver] resolver class
+    # @raises [NameError]
+    def self.detect_resolver(name)
+      name = Bogo::Utility.snake(name).gsub("::", "_")
+      @@resolvers.each do |klass_name, klass|
+        return klass if klass_name.end_with?(name)
+      end
+      raise NameError.new("Unknown resolver requested `#{name}` - #{resolvers}")
+    end
+
+    # @return [Hash] sfn config
+    attr_reader :config
+
+    # Resolver initialization. It is provided
+    # the configuration from sfn to allow for
+    # any required customizations
+    #
+    # @param config [Hash] sfn config
+    # @return [self]
+    def initialize(config)
+      @config = config
+      setup
+    end
+
+    # Run any required setup for the resolver
+    def setup; end
+
+    # Resolve the given value. Value will be
+    # a Hash type but should be validated
+    # locally
+    #
+    # @param value [Hash]
+    # @return [Object]
+    def resolve(value)
+      raise NotImplementedError
+    end
+  end
+end

--- a/test/rspecs/infrastructure_rspec.rb
+++ b/test/rspecs/infrastructure_rspec.rb
@@ -1,0 +1,236 @@
+require_relative "./base"
+
+describe Sfn::Callback::ParametersInfrastructure do
+  let(:ui) { double("ui") }
+  let(:config) { Smash.new }
+  let(:arguments) { [] }
+  let(:api) { double("api") }
+  let(:instance) { described_class.new(ui, config, arguments, api) }
+
+  before { allow(ui).to receive(:debug) }
+
+  describe "#load_file_for" do
+    let(:stack_name) { "TEST-STACK" }
+    let(:file_paths) { [] }
+
+    before { allow(Dir).to receive(:glob).and_return(file_paths) }
+
+    context "when no valid paths exist" do
+      it "should return an empty value" do
+        expect(instance.send(:load_file_for, stack_name)).to be_empty
+      end
+    end
+
+    context "when multiple valid paths exist" do
+      let(:file_paths) { ["PATH1", "PATH2"] }
+
+      it "should raise an error" do
+        expect { instance.send(:load_file_for, stack_name) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when single valid path exists" do
+      let(:file_paths) { ["FILE_PATH"] }
+      let(:bogo_config) { double("bogo_config", data: {}) }
+
+      before { allow(Bogo::Config).to receive(:new).and_return(bogo_config) }
+      after { instance.send(:load_file_for, stack_name) }
+
+      it "should load data from file" do
+        expect(Bogo::Config).to receive(:new).with(file_paths.first).
+                                  and_return(bogo_config)
+      end
+
+      it "should extract data from from file" do
+        expect(bogo_config).to receive(:data)
+      end
+
+      it "should unlock the data" do
+        expect(instance).to receive(:unlock_content).with(bogo_config.data)
+      end
+    end
+  end
+
+  describe "#process_information_hash" do
+    let(:info_hash) { Smash.new }
+    let(:path) { [] }
+    let(:config) {
+      Smash.new(
+        :parameters => Smash.new,
+        :compile_parameters => Smash.new,
+        :apply_stack => [],
+        :apply_mapping => Smash.new,
+      )
+    }
+
+    before { allow(instance).to receive(:config).and_return(config) }
+
+    context "when template is set" do
+      before { info_hash[:template] = "TEMPLATE" }
+
+      it "should set the file in the configuration" do
+        instance.send(:process_information_hash, info_hash, path)
+        expect(config[:file]).not_to be_nil
+        expect(config[:file]).to eq(info_hash[:template])
+      end
+    end
+
+    context "when parameters are set" do
+      let(:info_hash) {
+        Smash.new(
+          :parameters => {
+            :key1 => 1,
+            :key2 => 2,
+          },
+        )
+      }
+
+      it "should set parameters into config" do
+        instance.send(:process_information_hash, info_hash, path)
+        expect(config[:parameters][:key1]).to eq(1)
+        expect(config[:parameters][:key2]).to eq(2)
+      end
+
+      it "should load value through resolvers" do
+        expect(instance).to receive(:resolve).with(1)
+        expect(instance).to receive(:resolve).with(2)
+        instance.send(:process_information_hash, info_hash, path)
+      end
+
+      context "when parameter is set in config" do
+        before { config.set(:parameters, :key1, "VALUE") }
+
+        it "should not overwrite config" do
+          instance.send(:process_information_hash, info_hash, path)
+          expect(config[:parameters][:key1]).to eq("VALUE")
+          expect(config[:parameters][:key2]).to eq(2)
+        end
+      end
+    end
+
+    context "when compile time parameters are set" do
+      let(:info_hash) {
+        Smash.new(
+          :compile_parameters => {
+            :key1 => 1,
+            :key2 => 2,
+          },
+        )
+      }
+
+      it "should set compile parameters into config" do
+        instance.send(:process_information_hash, info_hash, path)
+        expect(config[:compile_parameters][:key1]).to eq(1)
+        expect(config[:compile_parameters][:key2]).to eq(2)
+      end
+
+      it "should load value through resolvers" do
+        expect(instance).to receive(:resolve).with(1)
+        expect(instance).to receive(:resolve).with(2)
+        instance.send(:process_information_hash, info_hash, path)
+      end
+
+      context "when compile parameter is set in config" do
+        before { config.set(:compile_parameters, :key1, "VALUE") }
+
+        it "should not overwrite config" do
+          instance.send(:process_information_hash, info_hash, path)
+          expect(config[:compile_parameters][:key1]).to eq("VALUE")
+          expect(config[:compile_parameters][:key2]).to eq(2)
+        end
+      end
+    end
+
+    context "with apply stacks set" do
+      let(:info_hash) { Smash.new(:apply_stacks => ["stack1"]) }
+
+      it "should add stack name to config apply stack list" do
+        instance.send(:process_information_hash, info_hash, path)
+        expect(config[:apply_stack]).to include("stack1")
+      end
+
+      context "when stack name already exists in config" do
+        before { config[:apply_stack] << "stack1" }
+
+        it "should not have duplicate names in apply stack" do
+          instance.send(:process_information_hash, info_hash, path)
+          expect(config[:apply_stack]).to eq(["stack1"])
+        end
+      end
+    end
+
+    context "with mappings set" do
+      let(:info_hash) { Smash.new(:mappings => {:first_key => :first_value}) }
+
+      it "should camel case value in config" do
+        instance.send(:process_information_hash, info_hash, path)
+        expect(config[:apply_mapping][:first_key]).to eq("FirstValue")
+      end
+    end
+  end
+
+  describe "#resolve" do
+    let(:value) { :value }
+
+    it "should return value when not a hash" do
+      expect(instance.send(:resolve, value)).to eq(value)
+    end
+
+    context "when value is a hash" do
+      let(:value) { {key: "value"} }
+
+      it "should return the given hash" do
+        expect(instance.send(:resolve, value)).to eq(value)
+      end
+
+      context "when value hash includes resolver name" do
+        let(:value) { {key: "value", resolver: resolver_name} }
+        let(:resolver_name) { "unknown_test_resolver" }
+
+        context "when resolver is not defined" do
+          it "should raise an error" do
+            expect { instance.send(:resolve, value) }.to raise_error(NameError)
+          end
+        end
+
+        context "when resolver is defined" do
+          instance_eval("class ::InfraTestResolver < SfnParameters::Resolver; def resolve(v); :resolved; end; end")
+
+          let(:resolver_name) { "infra_test_resolver" }
+
+          it "should resolve value through resolver" do
+            expect(instance.send(:resolve, value)).to eq(:resolved)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#load_resolver" do
+    let(:resolver_name) { "test_load_resolver" }
+    let(:resolver_class) { double("resolver_class") }
+    let(:resolver) { double("resolver") }
+
+    before { allow(resolver_class).to receive(:new).and_return(resolver) }
+
+    it "should memoize based on name" do
+      expect(instance).to receive(:memoize).with(resolver_name)
+      instance.send(:load_resolver, resolver_name)
+    end
+
+    it "should load the resolver" do
+      expect(SfnParameters::Resolver).to receive(:detect_resolver).
+                                           with(resolver_name).and_return(resolver_class)
+      instance.send(:load_resolver, resolver_name)
+    end
+
+    it "should not recreate the resolver instance" do
+      expect(SfnParameters::Resolver).to receive(:detect_resolver).
+                                           with(resolver_name).and_return(resolver_class)
+      expect(resolver_class).to receive(:new).and_return(resolver)
+      first = instance.send(:load_resolver, resolver_name)
+      second = instance.send(:load_resolver, resolver_name)
+      expect(first).to be(second)
+    end
+  end
+end

--- a/test/rspecs/resolver_rspec.rb
+++ b/test/rspecs/resolver_rspec.rb
@@ -1,0 +1,69 @@
+require "securerandom"
+require_relative "./base"
+
+describe SfnParameters::Resolver do
+  let(:resolver) do
+    klass_name = SecureRandom.uuid.gsub(/(\d|-)/, "").capitalize
+    instance_eval("class ::#{klass_name} < #{described_class.name}; end")
+    Object.const_get(klass_name)
+  end
+
+  before { described_class.reset! }
+  after { described_class.reset! }
+
+  describe ".inherited" do
+    it "should add class to list of resolvers" do
+      r = resolver
+      expect(described_class.resolvers).to include(r)
+    end
+
+    it "should not allow unnamed subclasses" do
+      expect { Class.new(described_class) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe ".resolvers" do
+    it "should return empty list when no resolvers are defined" do
+      expect(described_class.resolvers).to be_empty
+    end
+
+    it "should return list of defined resolvers" do
+      resolver # forces creation of resolver
+      expect(described_class.resolvers).not_to be_empty
+    end
+  end
+
+  describe ".detect_resolver" do
+    it "should find resolver by name" do
+      r_name = resolver.name
+      expect(described_class.detect_resolver(r_name)).to eq(resolver)
+    end
+
+    it "should find resolver without namespace" do
+      instance_eval("module Outer; class Inner < #{described_class.name}; end; end")
+      expect(described_class.detect_resolver("inner")).to be_kind_of(Class)
+    end
+
+    it "should find resolver with namespace" do
+      instance_eval("module Outer; class Inner < #{described_class.name}; end; end")
+      expect(described_class.detect_resolver("outer_inner")).to be_kind_of(Class)
+    end
+
+    it "should raise error when resolver is not found" do
+      expect { described_class.detect_resolver("unknown") }.to raise_error(NameError)
+    end
+  end
+
+  describe "#setup" do
+    it "should call setup when new instance is created" do
+      expect_any_instance_of(described_class).to receive(:setup)
+      described_class.new(nil)
+    end
+  end
+
+  describe "#resolve" do
+    it "should raise a not implemented error" do
+      expect { described_class.new(nil).resolve(nil) }.to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
This is a refactor of the great work in #18. New resolvers can be added without needing to update this library directly nor being within the same namespace. Also includes support for customized setup of resolvers with access to the sfn configuration (allowing user customization of resolvers). Test coverage also included (and added for the infrastructure file since no coverage existed previously).